### PR TITLE
 Use a relative import for sre_constants so it does not collide with the built-in module

### DIFF
--- a/gixy/core/sre_parse/sre_parse.py
+++ b/gixy/core/sre_parse/sre_parse.py
@@ -14,7 +14,7 @@ from __future__ import print_function
 
 """Internal support module for sre"""
 
-from sre_constants import *
+from .sre_constants import *
 
 SPECIAL_CHARS = ".\\[{()*+?^$|"
 REPEAT_CHARS = "*+?{"


### PR DESCRIPTION
If you don't use a relative import in python 3.13, you get this error:

```
gixy/formatters/__init__.py:2: in <module>
    from gixy.formatters.base import BaseFormatter
gixy/formatters/base.py:4: in <module>
    from gixy.directives import block
gixy/directives/__init__.py:2: in <module>
    from gixy.directives.directive import Directive
gixy/directives/directive.py:3: in <module>
    from gixy.core.variable import Variable
gixy/core/variable.py:4: in <module>
    from gixy.core.regexp import Regexp
gixy/core/regexp.py:11: in <module>
    import gixy.core.sre_parse.sre_parse as sre_parse
gixy/core/sre_parse/sre_parse.py:61: in <module>
    "t": SRE_FLAG_TEMPLATE,
E   NameError: name 'SRE_FLAG_TEMPLATE' is not defined
```

This is because `import sre_constants` will try to import from the built-in module rather than from the `sre_constants.py` in gixy.