### PR TITLE
Update python tests to test up through 3.13

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/gixy/core/sre_parse/sre_parse.py
+++ b/gixy/core/sre_parse/sre_parse.py
@@ -14,7 +14,7 @@ from __future__ import print_function
 
 """Internal support module for sre"""
 
-from sre_constants import *
+from .sre_constants import *
 
 SPECIAL_CHARS = ".\\[{()*+?^$|"
 REPEAT_CHARS = "*+?{"


### PR DESCRIPTION
Depends on #11 

This sets up testing for all supported python versions.  It is branched off #11 .