### PR TITLE
Update documentation for python support to match actually supported python versions

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ GIXY
 Gixy is a tool to analyze Nginx configuration.
 The main goal of Gixy is to prevent security misconfiguration and automate flaw detection.
 
-Currently supported Python versions are 3.6, 3.7, 3.8 and 3.9.
+Currently supported Python versions are 3.6 through 3.13.
 
 Disclaimer: Gixy is well tested only on GNU/Linux, other OSs may have some issues.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ GIXY
 Gixy is a tool to analyze Nginx configuration.
 The main goal of Gixy is to prevent security misconfiguration and automate flaw detection.
 
-Currently supported Python versions are 2.7, 3.6, 3.7, 3.8 and 3.9.
+Currently supported Python versions are 3.6 through 3.13.
 
 Disclaimer: Gixy is well tested only on GNU/Linux, other OSs may have some issues.
 

--- a/gixy/core/sre_parse/sre_parse.py
+++ b/gixy/core/sre_parse/sre_parse.py
@@ -14,7 +14,7 @@ from __future__ import print_function
 
 """Internal support module for sre"""
 
-from sre_constants import *
+from .sre_constants import *
 
 SPECIAL_CHARS = ".\\[{()*+?^$|"
 REPEAT_CHARS = "*+?{"

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     include_package_data=True,
 )


### PR DESCRIPTION
The documentation around what versions of python that gixy supported is out of date, especially after #12 is merged.  Update the documentation.

Depends on #12 .