### PR TITLE
Ensure that a variable is used in the path when using request_uri, and do not warn on proxy_pass_normalized if request_uri is used

### DIFF
--- a/gixy/directives/directive.py
+++ b/gixy/directives/directive.py
@@ -46,12 +46,12 @@ class Directive:
     def variables(self):
         raise NotImplementedError()
 
-    def find_directive_in_scope(self, name):
-        """Find directive in the current scope"""
+    def find_directives_in_scope(self, name):
+        """Find directives in the current scope"""
         for parent in self.parents:
             directive = parent.some(name, flat=False)
             if directive:
-                return directive
+                yield directive
         return None
 
     def __str__(self):

--- a/gixy/plugins/try_files_is_evil_too.py
+++ b/gixy/plugins/try_files_is_evil_too.py
@@ -18,8 +18,8 @@ class try_files_is_evil_too(Plugin):
 
     def audit(self, directive):
         # search for open_file_cache ...; on the same or higher level
-        open_file_cache = directive.find_directive_in_scope("open_file_cache")
-        if not open_file_cache or open_file_cache.args[0] == "off":
+        open_file_cache = list(directive.find_directives_in_scope("open_file_cache"))
+        if not open_file_cache or open_file_cache[0].args[0] == "off":
             self.add_issue(
                 severity=gixy.severity.MEDIUM,
                 directive=[directive],

--- a/tests/plugins/simply/proxy_pass_normalized/missing_variable.conf
+++ b/tests/plugins/simply/proxy_pass_normalized/missing_variable.conf
@@ -1,0 +1,7 @@
+location /b {
+  rewrite ^ $request_uri; # Sets the $1/$uri variable to the raw path
+  proxy_pass http://127.0.0.1:8000/; # No $1 or $uri or other variable, resulting in path being double-encoded
+}
+
+# Request received by nginx: /%2F
+# Request received by backend: /%252F

--- a/tests/plugins/simply/proxy_pass_normalized/missing_variable_fp.conf
+++ b/tests/plugins/simply/proxy_pass_normalized/missing_variable_fp.conf
@@ -1,0 +1,7 @@
+location /b {
+  rewrite ^ $request_uri; # Sets the $1/$uri variable to the raw path
+  proxy_pass http://127.0.0.1:8000/$1; # $1 used, resulting in path being passed as the raw path from the original request.
+}
+
+# Request received by nginx: /%2F
+# Request received by backend: /%2F # Possibly also receives //%2F)

--- a/tests/plugins/simply/proxy_pass_normalized/missing_variable_nopath.conf
+++ b/tests/plugins/simply/proxy_pass_normalized/missing_variable_nopath.conf
@@ -1,0 +1,7 @@
+location /b {
+  rewrite ^ $request_uri; # Sets the $1/$uri variable to the raw path
+  proxy_pass http://127.0.0.1:8000; # No $1 or $uri or other variable in either host or path, resulting in path being double-encoded
+}
+
+# Request received by nginx: /%2F
+# Request received by backend: /%252F

--- a/tests/plugins/simply/proxy_pass_normalized/missing_variable_nopath_fp.conf
+++ b/tests/plugins/simply/proxy_pass_normalized/missing_variable_nopath_fp.conf
@@ -1,0 +1,8 @@
+location /b {
+  rewrite ^ $request_uri; # Sets the $1/$uri variable to the raw path
+  proxy_pass http://127.0.0.1:8000$1; # $1 used in host, resulting in path being passed as the raw path from the original request.
+}
+
+# Request received by nginx: /%2F
+# Request received by backend: /%2F # Possibly also receives //%2F)
+# This is actually no different than proxy_pass_path_fp.conf since $1 is not a path.

--- a/tests/plugins/simply/proxy_pass_normalized/proxy_pass_path.conf
+++ b/tests/plugins/simply/proxy_pass_normalized/proxy_pass_path.conf
@@ -1,3 +1,6 @@
 location / {
-  proxy_pass http://server/;
+  proxy_pass http://server/; # Path "/" used, resulting in proxy_pass urldecoding the path.
 }
+
+# Request received by nginx: /%2F
+# Request received by backend: //

--- a/tests/plugins/simply/proxy_pass_normalized/proxy_pass_path_fp.conf
+++ b/tests/plugins/simply/proxy_pass_normalized/proxy_pass_path_fp.conf
@@ -1,3 +1,6 @@
 location / {
-  proxy_pass http://downstream;
+  proxy_pass http://downstream; # No rewrite rules, and no path used: no extra/missing urldecoding/urlencoding occurs.
 }
+
+# Request received by nginx: /%2F
+# Request received by backend: /%2F

--- a/tests/plugins/simply/proxy_pass_normalized/rewrite_with_return_fp.conf
+++ b/tests/plugins/simply/proxy_pass_normalized/rewrite_with_return_fp.conf
@@ -1,0 +1,9 @@
+location /1/ {
+  rewrite ^ $request_uri; # Sets $1/$uri to raw path.
+  rewrite ^/1(/.*) $1 break; # Extracts everything after /1 and places it into $1/$uri.
+  return 400; # extremely important! # If rewrite rule does not break (e.g. //1/), return 400, otherwise the location-block will fall-through and proxy_pass will not actually happen at all.
+  proxy_pass http://127.0.0.1:8080/$1; # $1 used, resulting in path being passed as the raw path from the original request.
+}
+
+# Request received by nginx: /1/%2F
+# Request received by backend: /%2F (or possibly //%2F)

--- a/tests/plugins/simply/rewrite_with_return.conf
+++ b/tests/plugins/simply/rewrite_with_return.conf
@@ -1,0 +1,9 @@
+location /1/ {
+  rewrite ^ $request_uri; # Sets $1/$uri to raw path
+  rewrite ^/1(/.*) $1 break; # Extracts everything after /1
+  return 400; # extremely important! # If rewrite rule does not break (e.g. //1/), return 400, otherwise the location-block will fall-through.
+  proxy_pass http://127.0.0.1:8080; # No $1 or $uri or other variable, resulting in path being double-encoded
+}
+
+# Request received by nginx: /1/%2F
+# Request received by backend: /%252F (or possibly //%252F)


### PR DESCRIPTION
In my previous PR, I messed up the "valid" proxy_pass directive.

```
location /1/ {
  rewrite ^ $request_uri;
  rewrite ^/1(/.*) $1 break;
  return 400; # extremely important!
  proxy_pass http://127.0.0.1:8080;
}
```
will cause the backend server to receive a double-encoded path.

The correct configuration should be:

```
location /1/ {
  rewrite ^ $request_uri;
  rewrite ^/1(/.*) $1 break;
  return 400; # extremely important!
  proxy_pass http://127.0.0.1:8080/$1; # or http://127.0.0.1:8080$1; -- http://127.0.0.1:8080/ will NOT work and http://127.0.0.1:8080; will NOT work, as they will produce double-encoded paths.
}
```

This PR fixes that. It ensures that a warning is only shown if proxy_pass is used with a path and $1 is not set to $request_uri.

It also warns if $request_uri is used, but no variable is actually set in the proxy_pass directive (which will now warn on anybody that used my incorrect solution)