### PR TITLE
regex_redos.py: Check whether location-block contains ReDoS regexp.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ GIXY
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/dvershinin/gixy.svg?style=flat-square)](https://github.com/dvershinin/gixy/pulls)
 
 > [!TIP]
-> This is an **actively maintained fork** of the original [Gixy](https://github.com/yandex/gixy) project by **Yandex LLC**.  
+> This is an **actively maintained fork** of the original [Gixy](https://github.com/yandex/gixy) project by **Yandex LLC**.
 
 # Overview
 <img align="right" width="192" height="192" src="docs/gixy.png">
@@ -43,6 +43,7 @@ Right now Gixy can find:
 *   [[worker_rlimit_nofile_vs_connections] `worker_rlimit_nofile` must be at least twice `worker_connections`](https://gixy.getpagespeed.com/en/plugins/worker_rlimit_nofile_vs_connections/)
 *   [[error_log_off] `error_log` set to `off`](https://gixy.getpagespeed.com/en/plugins/error_log_off/)
 *   [[unanchored_regex] Regular expression without anchors](https://gixy.getpagespeed.com/en/plugins/unanchored_regex/)
+*   [[regex_redos] Regular expressions may result in easy denial-of-service (ReDoS) attacks](https://joshua.hu/regex-redos-recheck-nginx-gixy)
 
 You can find things that Gixy is learning to detect at [Issues labeled with "new plugin"](https://github.com/dvershinin/gixy/issues?q=is%3Aissue+is%3Aopen+label%3A%22new+plugin%22)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ Right now Gixy can find:
 *   [[resolver_external] Using external DNS nameservers](https://blog.zorinaq.com/nginx-resolver-vulns/)
 *   [[version_disclosure] Using insecure values for server_tokens](en/plugins/version_disclosure.md)
 *   [[proxy_pass_normalized] Using proxy_pass with a pathname will normalize and decode the requested path when proxying](https://joshua.hu/proxy-pass-nginx-decoding-normalizing-url-path-dangerous#nginx-proxy_pass)
+*   [[regex_redos] Regular expressions may result in easy denial-of-service (ReDoS) attacks](https://joshua.hu/regex-redos-recheck-nginx-gixy)
 
 You can find things that Gixy is learning to detect at [Issues labeled with "new plugin"](https://github.com/dvershinin/gixy/issues?q=is%3Aissue+is%3Aopen+label%3A%22new+plugin%22)
 

--- a/gixy/plugins/regex_redos.py
+++ b/gixy/plugins/regex_redos.py
@@ -1,0 +1,118 @@
+import requests
+import gixy
+from gixy.plugins.plugin import Plugin
+
+
+class regex_redos(Plugin):
+    r"""
+    This plugin checks all directives for regular expressions that may be
+    vulnerable to ReDoS (Regular Expression Denial of Service). ReDoS
+    vulnerabilities may be used to overwhelm nginx servers with minimal
+    resources from an attacker.
+
+    Example of a vulnerable directive:
+        location ~ ^/(a|aa|aaa|aaaa)+$
+
+    Accessing the above location with a path such as
+    /aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab
+    can result in catastrophic backtracking.
+
+    This plugin relies on an external, public API to determine vulnerability.
+    Because of this network-dependence, and the fact that potentially private
+    expressions are sent over the network, usage of this plugin requires
+    the --regex-redos-url flag. This flag must specify the full URL to a
+    service which can be queried with expressions, responding with a report
+    matching the https://github.com/makenowjust-labs/recheck format.
+
+    An implementation of a compatible server:
+    https://github.com/MegaManSec/recheck-http-api
+    """
+
+    summary = (
+        'Detect directives with regexes that are vulnerable to '
+        'Regular Expression Denial of Service (ReDoS).'
+    )
+    severity = gixy.severity.HIGH
+    unknown_severity = gixy.severity.UNSPECIFIED
+    description = (
+        'Regular expressions with the potential for catastrophic backtracking '
+        'allow an nginx server to be denial-of-service attacked with very low '
+        'resources (also known as ReDoS).'
+    )
+    help_url = 'https://joshua.hu/regex-redos-recheck-nginx-gixy'
+    directives = ['location']  # XXX: Missing server_name, rewrite, if, map, proxy_redirect
+    options = {
+        'url': ""
+    }
+    skip_test = True
+
+    def __init__(self, config):
+        super(regex_redos, self).__init__(config)
+        self.redos_server = self.config.get('url')
+
+    def audit(self, directive):
+        # If we have no ReDoS check URL, skip.
+        if not self.redos_server:
+            return
+
+        # Only process directives that have regex modifiers.
+        if directive.modifier not in ('~', '~*'):
+            return
+
+        regex_pattern = directive.path
+        fail_reason = f'Could not check regex {regex_pattern} for ReDoS.'
+
+        modifier = "" if directive.modifier == "~" else "i"
+        json_data = {"1": {"pattern": regex_pattern, "modifier": modifier}}
+
+        # Attempt to contact the ReDoS check server.
+        try:
+            response = requests.post(
+                self.redos_server,
+                json=json_data,
+                headers={"Content-Type": "application/json"},
+                timeout=60
+            )
+        except requests.RequestException:
+            self.add_issue(directive=directive, reason=fail_reason, severity=self.unknown_severity)
+            return
+
+        # If we get a non-200 response, skip.
+        if response.status_code != 200:
+            self.add_issue(directive=directive, reason=fail_reason, severity=self.unknown_severity)
+            return
+
+        # Attempt to parse the JSON response.
+        try:
+            response_json = response.json()
+        except ValueError:
+            self.add_issue(directive=directive, reason=fail_reason, severity=self.unknown_severity)
+            return
+
+        # Ensure the expected data structure is present and matches the pattern.
+        if (
+            "1" not in response_json or
+            response_json["1"] is None or
+            "source" not in response_json["1"] or
+            response_json["1"]["source"] != regex_pattern
+        ):
+            self.add_issue(directive=directive, reason=fail_reason, severity=self.unknown_severity)
+            return
+
+        recheck = response_json["1"]
+        status = recheck.get("status")
+
+        # If status is neither 'vulnerable' nor 'unknown', the expression is safe.
+        if status not in ("vulnerable", "unknown"):
+            return
+
+        # If the status is unknown, add a low-severity issue (likely the server timed out)
+        if status == "unknown":
+            reason = f'Could not check complexity of regex {regex_pattern}.'
+            self.add_issue(directive=directive, reason=reason, severity=self.unknown_severity)
+            return
+
+        # Status is 'vulnerable' here. Report as a high-severity issue.
+        complexity_summary = recheck.get("complexity", {}).get("summary", "unknown")
+        reason = f'Regex is vulnerable to {complexity_summary} ReDoS: {regex_pattern}.'
+        self.add_issue(directive=directive, reason=reason, severity=self.severity)

--- a/tests/plugins/test_simply.py
+++ b/tests/plugins/test_simply.py
@@ -46,6 +46,8 @@ def generate_config_test_cases():
 
     manager = PluginsManager()
     for plugin in manager.plugins:
+        if getattr(plugin, 'skip_test', False):
+            continue
         plugin = plugin.name
         assert plugin in tested_plugins, 'Plugin {name!r} should have at least one simple test config'.format(name=plugin)
         assert plugin in tested_fp_plugins, 'Plugin {name!r} should have at least one simple test config with false positive'.format(name=plugin)


### PR DESCRIPTION
This plugin queries an external server (which must be set by by the caller) to check for any regular expressions used in location-blocks that are vulnerable to ReDoS vulnerabilities.

It is with great displeasure to provide this plugin in this format: by calling a web API. However, there is simply no other solution. This plugin is disabled by default, and requires an external HTTP server to setup to be used.

At the moment, only location blocks are checked, however in the future, more directives can be checked.

Amendments to this PR are highly appreciated.

Since it requires an external server, no checks are added.

Fixes #25.