### PR TITLE
Support geo and map directives. Add hash_without_default.py.

### DIFF
--- a/gixy/core/builtin_variables.py
+++ b/gixy/core/builtin_variables.py
@@ -381,3 +381,6 @@ def builtin_var(name):
             return Variable(name=name, value=Regexp(regexp, strict=True, case_sensitive=False))
         return Variable(name=name, value='builtin', have_script=False)
     return None
+
+def fake_var(name):
+    return Variable(name=name, value=name, have_script=False)

--- a/gixy/core/context.py
+++ b/gixy/core/context.py
@@ -2,7 +2,6 @@ import logging
 import copy
 
 from gixy.core.utils import is_indexed_name
-import gixy.core.builtin_variables as builtins
 
 LOG = logging.getLogger(__name__)
 
@@ -72,6 +71,7 @@ class Context(object):
         except KeyError:
             if var_type == 'name':
                 # Only named variables can be builtins
+                import gixy.core.builtin_variables as builtins
                 if builtins.is_builtin(name):
                     result = builtins.builtin_var(name)
 
@@ -83,6 +83,7 @@ class Context(object):
                 except KeyError:
                     # It may actually be another variable outside of the same http context, but we have no way to traverse up and down all contexts.
                     # So, just create a fake variable with the same name, and the caller can use compile_script during a second pass if it wants to resolve the variable.
+                    import gixy.core.builtin_variables as builtins
                     result = builtins.fake_var(name)
 
         return result

--- a/gixy/core/manager.py
+++ b/gixy/core/manager.py
@@ -4,6 +4,7 @@ import logging
 import gixy
 from gixy.core.plugins_manager import PluginsManager
 from gixy.core.context import get_context, pop_context, push_context, purge_context
+from gixy.directives.directive import MapDirective
 from gixy.parser.nginx_parser import NginxParser
 from gixy.core.config import Config
 from gixy.core import builtin_variables as builtins
@@ -71,7 +72,7 @@ class Manager(object):
 
         context = get_context()
         for var in directive.variables:
-            if var.name == 0:
+            if var.name == 0 and not isinstance(directive, MapDirective):
                 # All regexps must clean indexed variables
                 context.clear_index_vars()
             context.add_var(var.name, var)

--- a/gixy/core/variable.py
+++ b/gixy/core/variable.py
@@ -10,7 +10,7 @@ LOG = logging.getLogger(__name__)
 EXTRACT_RE = re.compile(r"\$([1-9]|[a-z_][a-z0-9_]*|\{[a-z0-9_]+\})", re.IGNORECASE)
 
 
-def compile_script(script):
+def compile_script(script, ctx=None):
     """
     Compile Nginx script to list of variables.
     Example:
@@ -25,13 +25,15 @@ def compile_script(script):
     for i, var in enumerate(EXTRACT_RE.split(str(script))):
         if i % 2:
             # Variable
-            var = var.strip("{}\x20")
-            var = context.get_var(var)
+            var_val = var.strip("{}\x20")
+            var = context.get_var(var_val, ctx=ctx)
             if var:
                 depends.append(var)
+            else:
+                LOG.info("Can't find variable '{0}' in script '{1}' inside block '{2}'.".format(var_val, script, str(context.block).replace("\n", " ")))
         elif var:
             # Literal
-            depends.append(Variable(name=None, value=var, have_script=False))
+            depends.append(Variable(name=None, value=var, have_script=False, ctx=ctx))
     return depends
 
 
@@ -40,9 +42,10 @@ class Variable(object):
         self,
         name,
         value=None,
-        boundary: Optional[Regexp] = None,
+        boundary=None,
         provider=None,
         have_script=True,
+        ctx=None,
     ):
         """
         Gixy Nginx variable class - parse and provide helpers to work with it.
@@ -52,6 +55,7 @@ class Variable(object):
         :param Regexp boundary: variable boundary set.
         :param Directive provider: directive that provide variable (e.g. if, location, rewrite, etc.).
         :param bool have_script: may variable have nginx script or not (mostly used to indicate a string literal).
+        :param str ctx: used for MapBlock/GeoBlock and MapDirective encapsulation
         """
 
         self.name = name
@@ -60,10 +64,24 @@ class Variable(object):
         self.depends = None
         self.boundary = boundary
         self.provider = provider
+        self.final_value = value
+        self.ctx = ctx
         if isinstance(value, Regexp):
             self.regexp = value
         elif have_script:
-            self.depends = compile_script(value)
+            self.depends = compile_script(value, ctx) # XXX: Do we want to append new_depends below?
+            for iteration in range(10): # 10 is arbitrary, just avoid infinite loop (is it possible?)
+                new_depends = compile_script(self.final_value, ctx)
+                if len(new_depends) == 0:
+                    break
+                if type(new_depends[0].value) is list: # MapBlock, GeoBlock cannot be infinitely resolved
+                    self.final_value = self.value
+                    break
+                if len(new_depends) == 1 and self.final_value == new_depends[0].value:
+                    break
+                self.depends = new_depends
+                all_vars = [str(i.value) for i in new_depends]
+                self.final_value = ''.join(all_vars)
 
     def can_contain(self, char):
         """
@@ -84,6 +102,19 @@ class Variable(object):
         # Then dependencies
         if self.depends:
             return any(dep.can_contain(char) for dep in self.depends)
+
+        # If the value is a list (hash block), check all dest_val values
+        if isinstance(self.value, list):
+            for var in self.value:
+                if not isinstance(var, Variable) or not var.provider or var.provider.nginx_name != 'map': # import MapDirective would be better but circular import..
+                    continue # break?
+                if var.provider.parent.nginx_name != 'map': # import MapBlock would be better but circular import..
+                    continue # break?
+
+                compiled_val = compile_script(var.provider.dest_val, ctx=var.provider.src_val) # Doesn't work for 'map $document_uri $v { ~*^[^\r\n]+$ $document_uri; }' but nothing we can do about that.
+                for dep in compiled_val:
+                    if dep.can_contain(char):
+                        return True
 
         # Otherwise user can't control value of this variable
         return False
@@ -108,6 +139,19 @@ class Variable(object):
         if self.depends:
             return self.depends[0].can_startswith(char)
 
+        # If the value is a list (hash block), check all values
+        if isinstance(self.value, list):
+            for var in self.value:
+                if not isinstance(var, Variable) or not var.provider or var.provider.nginx_name != 'map':
+                    continue
+                if var.provider.parent.nginx_name != 'map':
+                    continue
+
+                compiled_val = compile_script(var.provider.dest_val, ctx=var.provider.src_val)
+                if compiled_val:
+                    if compiled_val[0].can_startswith(char):
+                        return True
+
         # Otherwise user can't control value of this variable
         return False
 
@@ -131,6 +175,26 @@ class Variable(object):
         if self.depends:
             return any(dep.must_contain(char) for dep in self.depends)
 
+        # If the value is a list (hash block), check all values
+        if isinstance(self.value, list):
+            # Ensure that every map value must contain the char
+            for var in self.value:
+                if not isinstance(var, Variable) or not var.provider or var.provider.nginx_name != 'map':
+                    continue
+                if var.provider.parent.nginx_name != 'map':
+                    continue
+
+                compiled_val = compile_script(var.provider.dest_val, ctx=var.provider.src_val)
+                found_must_contain = False
+                for dep in compiled_val:
+                    if dep.must_contain(char):
+                        found_must_contain = True
+                        break
+                if not found_must_contain: # A map value doesn't need to contain the char, therefore return False
+                    return False
+
+            return True
+
         # Otherwise checks literal
         return self.value and char in self.value
 
@@ -153,6 +217,20 @@ class Variable(object):
         # Then dependencies
         if self.depends:
             return self.depends[0].must_startswith(char)
+
+        # If the value is a list (hash block), check all values
+        if isinstance(self.value, list):
+            for var in self.value:
+                if not isinstance(var, Variable) or not var.provider or var.provider.nginx_name != 'map':
+                    continue
+                if var.provider.parent.nginx_name != 'map':
+                    continue
+
+                compiled_val = compile_script(var.provider.dest_val, ctx=var.provider.src_val)
+                if not compiled_val or not compiled_val[0].must_startswith(char):
+                    return False
+
+            return True
 
         # Otherwise checks literal
         return self.value and self.value[0] == char

--- a/gixy/directives/block.py
+++ b/gixy/directives/block.py
@@ -227,7 +227,6 @@ class MapBlock(Block):
     @cached_property
     def variables(self):
         vars = []
-        # final_source = Regexp(Variable(name="", value=self.source, provider=self).final_value)
         for child in list(self.gather_map_directives(self.children)):
             if not isinstance(child, MapDirective):
                 continue # XXX: Should never happen?
@@ -312,7 +311,6 @@ class GeoBlock(Block):
     @cached_property
     def variables(self):
         vars = []
-        # final_source = Regexp(Variable(name="", value=self.source, provider=self).final_value)
         for child in list(self.gather_geo_directives(self.children)):
             src_val = child.src_val
             dest_val = child.dest_val

--- a/gixy/directives/directive.py
+++ b/gixy/directives/directive.py
@@ -306,7 +306,7 @@ class MapDirective(Directive):
     }
 
     geo [$remote_addr] $destination {
-      default        ZZ;
+      default        ZZ; <-- this part.
       include        conf/geo.conf; <-- this part.
       delete         127.0.0.0/16; <-- this part.
       proxy          192.168.100.0/24; <-- this part.

--- a/gixy/formatters/base.py
+++ b/gixy/formatters/base.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import gixy
 from gixy.directives import block
+from gixy.directives.block import MapBlock, GeoBlock
 
 
 class BaseFormatter(object):
@@ -44,6 +45,14 @@ class BaseFormatter(object):
                 reason=issue.reason or '',
             )
             key = ''.join(report.values())
+            expanded_directives = []
+            if any(isinstance(value, (MapBlock, GeoBlock)) for value in issue.directives):
+                for value in issue.directives:
+                    if isinstance(value, (MapBlock, GeoBlock)):
+                        expanded_directives.extend(value.children)
+                    else:
+                        expanded_directives.append(value)
+                issue.directives = expanded_directives
             report['directives'] = issue.directives
             if key in result:
                 result[key]['directives'].extend(report['directives'])

--- a/gixy/parser/nginx_parser.py
+++ b/gixy/parser/nginx_parser.py
@@ -21,6 +21,7 @@ class NginxParser(object):
         self.directives = {}
         self.parser = raw_parser.RawParser()
         self._init_directives()
+        self._path_stack = None
 
     def parse_file(self, path, root=None):
         LOG.debug("Parse file: {0}".format(path))
@@ -28,6 +29,9 @@ class NginxParser(object):
         return self.parse(content=content, root=root, path_info=path)
 
     def parse(self, content, root=None, path_info=None):
+        if path_info is not None:
+            self._path_stack = path_info
+
         if not root:
             root = block.Root()
         try:
@@ -50,11 +54,14 @@ class NginxParser(object):
             #  Were parse nginx dump
             LOG.info("Switched to parse nginx configuration dump.")
             root_filename = self._prepare_dump(parsed)
+            if self.path_info:
+                self._path_stack = path_info # XXX: hack because parse() is called in tests without setting _path_stack
             self.is_dump = True
             self.cwd = os.path.dirname(root_filename)
             parsed = self.configs[root_filename]
 
         self.parse_block(parsed, root)
+        self._path_stack = path_info
         return root
 
     def parse_block(self, parsed_block, parent):
@@ -62,9 +69,18 @@ class NginxParser(object):
             parsed_type = parsed.getName()
             parsed_name = parsed[0]
             parsed_args = parsed[1:]
+            if parent.name in ['map', 'geo'] and parsed_type == 'directive': # Hack because included maps are treated as directives (bleh)
+                if len(parsed_args) > 1:
+                    error_msg = "Invalid map with {} parameters: map {} {} {{ {} {}; }};".format(len(parsed_args), parent.args[0], parent.args[1], parsed_name, ' '.join(parsed_args))
+                    LOG.warn('Failed to parse "{path_info}": {error}'.format(path_info=self.path_info, error=error_msg))
+                    continue
+
+                parsed_type = 'hash_value'
             if parsed_type == "include":
                 # TODO: WTF?!
+                path_info = self.path_info
                 self._resolve_include(parsed_args, parent)
+                self._path_stack = path_info
             else:
                 directive_inst = self.directive_factory(
                     parsed_type, parsed_name, parsed_args
@@ -98,6 +114,8 @@ class NginxParser(object):
             return block.Block
         elif parsed_type == "directive":
             return directive.Directive
+        elif parsed_type == "hash_value":
+            return directive.MapDirective
         elif parsed_type == "unparsed_block":
             LOG.warning('Skip unparseable block: "%s"', parsed_name)
             return None
@@ -157,3 +175,8 @@ class NginxParser(object):
                 continue
             self.configs[filename].append(parsed)
         return root_filename
+
+    @property
+    def path_info(self):
+        """Current file being parsed, or None."""
+        return self._path_stack if self._path_stack else None

--- a/gixy/plugins/hash_without_default.py
+++ b/gixy/plugins/hash_without_default.py
@@ -1,0 +1,21 @@
+import gixy
+from gixy.plugins.plugin import Plugin
+
+class hash_without_default(Plugin):
+    summary = "Detect when a hash block (map, geo) is used without a default value."
+    severity = gixy.severity.MEDIUM
+    description = "A hash block without a default value may allow the bypassing of security controls."
+    help_url = "https://joshua.hu/todo"
+    directives = ["map", "geo"]
+
+    def __init__(self, config):
+        super(hash_without_default, self).__init__(config)
+
+    def audit(self, directive):
+        found_default = False
+        for child in directive.children:
+            if child.src_val == 'default' and child.dest_val is not None:
+                found_default = True
+                break
+        if not found_default:
+            self.add_issue(directive=[directive] + directive.children, reason="Missing default value in {0} ${1}".format(directive.name, directive.variable))

--- a/gixy/plugins/ssrf.py
+++ b/gixy/plugins/ssrf.py
@@ -58,5 +58,6 @@ class ssrf(Plugin):
                 # Yay! Our variable can contain any symbols!
                 reason = 'At least variable "${var}" can contain untrusted user input'.format(var=var.name)
                 self.add_issue(directive=[directive] + var.providers, reason=reason)
+
                 return True
         return False

--- a/tests/directives/test_block.py
+++ b/tests/directives/test_block.py
@@ -207,6 +207,7 @@ def test_block_map():
     config = '''
 map $some_var $some_other_var {
     a   b;
+    ~*(.*) $1;
     default c;
 }
     '''
@@ -216,7 +217,12 @@ map $some_var $some_other_var {
     assert directive.is_block
     assert not directive.self_context
     assert directive.provide_variables
+    assert directive.source == '$some_var'
     assert directive.variable == 'some_other_var'
+    assert directive.children
+    assert len(directive.children) == 3
+    assert [c.src_val for c in directive.children] == ['a', '~*(.*)', 'default']
+    assert [c.dest_val for c in directive.children] == ['b', '$1', 'c']
 
 
 def test_block_geo_two_vars():
@@ -232,7 +238,12 @@ geo $some_var $some_other_var {
     assert directive.is_block
     assert not directive.self_context
     assert directive.provide_variables
+    assert directive.source == '$some_var'
     assert directive.variable == 'some_other_var'
+    assert directive.children
+    assert len(directive.children) == 2
+    assert [c.src_val for c in directive.children] == ['1.2.3.4', 'default']
+    assert [c.dest_val for c in directive.children] == ['b', 'c']
 
 
 def test_block_geo_one_var():
@@ -248,4 +259,9 @@ geo $some_var {
     assert directive.is_block
     assert not directive.self_context
     assert directive.provide_variables
+    assert directive.source == '$remote_addr'
     assert directive.variable == 'some_var'
+    assert directive.children
+    assert len(directive.children) == 2
+    assert [c.src_val for c in directive.children] == ['5.6.7.8', 'default']
+    assert [c.dest_val for c in directive.children] == ['d', 'e']

--- a/tests/parser/test_nginx_parser.py
+++ b/tests/parser/test_nginx_parser.py
@@ -36,11 +36,13 @@ def test_directive(config, expected):
 @pytest.mark.parametrize('config,expected', zip(
     [
         'if (-f /some) {}',
+        'map $uri $avar {}',
         'location / {}'
     ],
 
     [
         [Directive, Block, IfBlock],
+        [Directive, Block, MapBlock],
         [Directive, Block, LocationBlock],
     ]
 ))

--- a/tests/plugins/simply/hash_without_default/geo_no_default.conf
+++ b/tests/plugins/simply/hash_without_default/geo_no_default.conf
@@ -1,0 +1,5 @@
+http {
+  geo $hostmap {
+    value 1;
+  }
+}

--- a/tests/plugins/simply/hash_without_default/geo_no_default_fp.conf
+++ b/tests/plugins/simply/hash_without_default/geo_no_default_fp.conf
@@ -1,0 +1,5 @@
+http {
+  geo $hostmap {
+    default 1;
+  }
+}

--- a/tests/plugins/simply/hash_without_default/map_no_default.conf
+++ b/tests/plugins/simply/hash_without_default/map_no_default.conf
@@ -1,0 +1,5 @@
+http {
+  map $host $hostmap {
+    example.com value;
+  }
+}

--- a/tests/plugins/simply/hash_without_default/map_no_default_fp.conf
+++ b/tests/plugins/simply/hash_without_default/map_no_default_fp.conf
@@ -1,0 +1,6 @@
+http {
+  map $host $hostmap {
+    example.com value;
+    default default_val;
+  }
+}

--- a/tests/plugins/simply/http_splitting/mapped_value.conf
+++ b/tests/plugins/simply/http_splitting/mapped_value.conf
@@ -1,0 +1,7 @@
+map $host $map_host {
+  ~*/(.*) $1;
+  default 1;
+}
+
+
+add_header x-header $map_host;

--- a/tests/plugins/simply/http_splitting/mapped_value_2.conf
+++ b/tests/plugins/simply/http_splitting/mapped_value_2.conf
@@ -1,0 +1,7 @@
+map $host $map_host {
+  a_value $uri;
+  default 1;
+}
+
+
+add_header x-header $map_host;

--- a/tests/plugins/simply/http_splitting/mapped_value_3.conf
+++ b/tests/plugins/simply/http_splitting/mapped_value_3.conf
@@ -1,0 +1,10 @@
+map $host $another_map_host {
+  a_value $uri;
+  default 1;
+}
+map $host $map_host {
+  a_value $another_map_host;
+  default 1;
+}
+
+add_header x-header $map_host;

--- a/tests/plugins/simply/http_splitting/mapped_value_3_fp.conf
+++ b/tests/plugins/simply/http_splitting/mapped_value_3_fp.conf
@@ -1,0 +1,10 @@
+map $host $another_map_host {
+  default 1;
+}
+map $host $map_host {
+  a_value $another_map_host;
+  default 1;
+}
+
+
+add_header x-header $map_host;

--- a/tests/plugins/simply/http_splitting/mapped_value_4.conf
+++ b/tests/plugins/simply/http_splitting/mapped_value_4.conf
@@ -1,0 +1,13 @@
+map $host $another_another_map_host {
+  a_value $uri;
+  default 1;
+}
+map $host $another_map_host {
+  a_value $another_another_map_host;
+  default 1;
+}
+map $host $map_host {
+  a_value $another_map_host;
+  default 1;
+}
+add_header x-header $map_host;

--- a/tests/plugins/simply/http_splitting/mapped_value_4_fp.conf
+++ b/tests/plugins/simply/http_splitting/mapped_value_4_fp.conf
@@ -1,0 +1,12 @@
+map $host $another_another_map_host {
+  default 1;
+}
+map $host $another_map_host {
+  a_value $another_another_map_host;
+  default 1;
+}
+map $host $map_host {
+  a_value $another_map_host;
+  default 1;
+}
+add_header x-header $map_host;

--- a/tests/plugins/simply/http_splitting/mapped_value_fp.conf
+++ b/tests/plugins/simply/http_splitting/mapped_value_fp.conf
@@ -1,0 +1,7 @@
+map $host $map_host {
+  ~*/([^\r\n]*) $1;
+  default 1;
+}
+
+
+add_header x-header $map_host;

--- a/tests/plugins/simply/http_splitting/mapped_value_with_set.conf
+++ b/tests/plugins/simply/http_splitting/mapped_value_with_set.conf
@@ -1,0 +1,6 @@
+map $host $map_host {
+  a_value $uri;
+  default 1;
+}
+set $avar $map_host;
+add_header x-header $avar;

--- a/tests/plugins/simply/ssrf/mapped_value.conf
+++ b/tests/plugins/simply/ssrf/mapped_value.conf
@@ -1,0 +1,15 @@
+http {
+    map $uri $backend {
+        ~^/api/(.*)$ "$1";
+        default "http://localhost:8080";
+    }
+
+    server {
+        listen 80;
+
+        location / {
+            proxy_pass http://$backend;
+            proxy_set_header Host $host;
+        }
+    }
+}


### PR DESCRIPTION
Also: log more informative errors for unknown variables.

Closes #24.