### PR TITLE
chore: ensure that add_header_redefinition.py headers are deterministic

### DIFF
--- a/gixy/plugins/add_header_redefinition.py
+++ b/gixy/plugins/add_header_redefinition.py
@@ -69,7 +69,7 @@ class add_header_redefinition(Plugin):
         # Set severity based on whether a secure header was dropped
         issue_severity = gixy.severity.MEDIUM if is_secure_header_dropped else self.severity
 
-        reason = 'Parent headers "{headers}" was dropped in current level'.format(headers='", "'.join(diff))
+        reason = 'Parent headers "{headers}" was dropped in current level'.format(headers='", "'.join(sorted(diff)))
         self.add_issue(directive=directives, reason=reason, severity=issue_severity)
 
 


### PR DESCRIPTION
Fixes long-standing issue where gixy reports are not consistent. Before, using `for i in {1..10}; do gixy -f json > /tmp/g/$i; done`:

```
# md5sum *
3611f4f8a74cbeb4ea49cf4c394cae70  1
edd492719b5b80da33061938b012cd25  10
5e35d8cbb5b9bc4a1e052d5e096c0950  2
3a0cab17e76bcf6c73c429bc5a53b4d7  3
44b99d2d2c1a2bfd93cba85490e20bd1  4
49fcd821e03ee52d881e035c4264ef38  5
5a3430e9072d1d32e99c24254d486e58  6
a97d74e25520fe280803b8a661f106bb  7
77b4244181a014ae2c0591078afe229f  8
5b1085472878e86be7646b8fcc315df6  9
```

after:

```
# md5sum *
88b241671e4ef376962d013bbfc91b6a  1
88b241671e4ef376962d013bbfc91b6a  10
88b241671e4ef376962d013bbfc91b6a  2
88b241671e4ef376962d013bbfc91b6a  3
88b241671e4ef376962d013bbfc91b6a  4
88b241671e4ef376962d013bbfc91b6a  5
88b241671e4ef376962d013bbfc91b6a  6
88b241671e4ef376962d013bbfc91b6a  7
88b241671e4ef376962d013bbfc91b6a  8
88b241671e4ef376962d013bbfc91b6a  9
```