### PR TITLE
Fix issue number 53

### DIFF
--- a/docs/en/plugins/invalid_regex_group.md
+++ b/docs/en/plugins/invalid_regex_group.md
@@ -1,0 +1,25 @@
+# invalid_regex_group
+
+- Summary: Rewrite references non-existent capture group
+- Severity: LOW
+
+## Description
+This check reports `rewrite` directives where the replacement string references numeric capture groups (e.g. `$1`, `$2`) that are not defined by the rewrite pattern.
+
+Example of problematic configuration:
+
+```nginx
+rewrite "(?i)/" $1 break;
+```
+
+In this case, the pattern has zero capturing groups, yet `$1` is referenced in the replacement. The plugin points precisely at the offending `rewrite` directive so you can adjust the pattern or the replacement accordingly.
+
+## Why it matters
+Using an undefined backreference in a replacement often indicates a logic error and can result in unintended URLs being generated.
+
+## Recommendation
+- Add the necessary capturing groups to the pattern, e.g. `^/(.*)` to use `$1`.
+- Or remove the backreference from the replacement if it is not intended.
+
+## References
+- NGINX `rewrite` directive documentation: `https://nginx.org/en/docs/http/ngx_http_rewrite_module.html#rewrite`

--- a/gixy/plugins/invalid_regex_group.py
+++ b/gixy/plugins/invalid_regex_group.py
@@ -1,0 +1,59 @@
+import re
+import gixy
+from gixy.plugins.plugin import Plugin
+from gixy.core.regexp import Regexp
+
+
+class invalid_regex_group(Plugin):
+    """
+    Detects usage of numeric backreferences in rewrite replacement that are not
+    provided by the rewrite pattern (e.g., using $1 without a capturing group).
+    """
+
+    summary = "Rewrite references non-existent capture group"
+    description = (
+        "The rewrite replacement references a numeric capture group (e.g., $1), "
+        "but the pattern does not define enough capturing groups."
+    )
+    help_url = (
+        "https://github.com/dvershinin/gixy/blob/master/docs/en/plugins/invalid_regex_group.md"
+    )
+    severity = gixy.severity.LOW
+    directives = ["rewrite"]
+
+    def audit(self, directive):
+        # Expecting a RewriteDirective-like object with pattern and replace attrs
+        try:
+            pattern = getattr(directive, "pattern", None)
+            replace = getattr(directive, "replace", None)
+            if not pattern or not replace:
+                return
+
+            # Count available capturing groups in the pattern
+            # groups dict includes key 0 for the whole match; we want numbered groups >= 1
+            regexp = Regexp(pattern, case_sensitive=True)
+            available_group_ids = [
+                k for k in regexp.groups.keys() if isinstance(k, int) and k >= 1
+            ]
+            max_available = max(available_group_ids) if available_group_ids else 0
+
+            # Find all numeric backrefs used in the replacement, support $1, $2, ... $10
+            used_group_ids = [int(m) for m in re.findall(r"\$(\d+)", str(replace))]
+            if not used_group_ids:
+                return
+
+            invalid_ids = sorted({g for g in used_group_ids if g > max_available})
+            if not invalid_ids:
+                return
+
+            # Build a clear reason message
+            invalid_list = ", ".join(f"${g}" for g in invalid_ids)
+            reason = (
+                f"Replacement references {invalid_list}, but pattern defines only "
+                f"{max_available} capture group(s)."
+            )
+            # Report at the rewrite directive location
+            self.add_issue(directive=directive, reason=reason)
+        except Exception:
+            # Be resilient; never break the analyzer for plugin errors
+            return

--- a/tests/plugins/simply/invalid_regex_group/config.json
+++ b/tests/plugins/simply/invalid_regex_group/config.json
@@ -1,0 +1,3 @@
+{
+  "severity": "LOW"
+}

--- a/tests/plugins/simply/invalid_regex_group/rewrite_undefined_group.conf
+++ b/tests/plugins/simply/invalid_regex_group/rewrite_undefined_group.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    server_name example.test;
+
+    location / {
+        # The pattern has zero capturing groups, but replacement uses $1
+        rewrite "(?i)/" $1 break;
+    }
+}

--- a/tests/plugins/simply/invalid_regex_group/rewrite_undefined_group_fp.conf
+++ b/tests/plugins/simply/invalid_regex_group/rewrite_undefined_group_fp.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    server_name example.test;
+
+    location / {
+        # No invalid group usage here
+        rewrite "(?i)/(.*)" $1 break;
+    }
+}


### PR DESCRIPTION
Add `invalid_regex_group` plugin to report `rewrite` directives referencing non-existent regex capture groups, fixing #53.

This addresses issue #53 by identifying and reporting `rewrite` directives where the replacement string attempts to use a numeric backreference (like `$1`) for a capture group that is not defined in the associated regex pattern. This prevents potential misconfigurations and unexpected URL behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c164e49-0c36-4d5a-a30b-bebc3d924158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3c164e49-0c36-4d5a-a30b-bebc3d924158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

