### PR TITLE
Parse capture groups in if-blocks (fixed for crossplane)

### DIFF
--- a/gixy/directives/block.py
+++ b/gixy/directives/block.py
@@ -4,7 +4,7 @@ except ImportError:
     from functools import cached_property
 
 from gixy.directives.directive import Directive, MapDirective
-from gixy.core.variable import Variable
+from gixy.core.variable import Variable, compile_script
 from gixy.core.regexp import Regexp
 
 
@@ -197,15 +197,30 @@ class IfBlock(Block):
           if ($var ~* (a)(b)) { return 301 /$1/$2; }
 
         We expose numeric backrefs like 0, 1, 2... similar to location ~ and rewrite.
+        The boundary is inherited from the source variable being tested (e.g., $request_uri).
         """
         # Only conditions with regex operators can yield capture groups
         if self.operand in ("~", "~*", "!~", "!~*") and self.value:
             case_sensitive = self.operand in ("~", "!~")
             regexp = Regexp(self.value, case_sensitive=case_sensitive)
+
+            # Get boundary from the source variable (e.g., $request_uri)
+            # This ensures capture groups inherit the source's constraints
+            boundary = None
+            if self.variable:
+                try:
+                    compiled = compile_script(self.variable)
+                    if len(compiled) == 1:
+                        # Use the source variable's regexp as boundary
+                        boundary = compiled[0].regexp
+                except (IndexError, AttributeError):
+                    # No context available (e.g., unit tests without full setup)
+                    pass
+
             result = []
             for name, group in regexp.groups.items():
                 result.append(
-                    Variable(name=name, value=group, boundary=group, provider=self)
+                    Variable(name=name, value=group, boundary=boundary, provider=self)
                 )
             return result
         return []

--- a/tests/plugins/simply/http_splitting/if_block.conf
+++ b/tests/plugins/simply/http_splitting/if_block.conf
@@ -1,0 +1,8 @@
+server {
+	server_name example.com;
+
+	if ($uri ~* ^/echo/(.*)$) {
+		return 301 $1;
+	}
+}
+

--- a/tests/plugins/simply/http_splitting/if_block_fp.conf
+++ b/tests/plugins/simply/http_splitting/if_block_fp.conf
@@ -1,0 +1,8 @@
+server {
+	server_name example.com;
+
+	if ($request_uri ~* ^/echo/(.*)$) {
+		return 301 $1;
+	}
+}
+


### PR DESCRIPTION
Based on the work from #51 by @MegaManSec, rebased and adapted for the crossplane-based parser.

This PR enables the `IfBlock` to provide variables from regex capture groups when using `~`, `~*`, `!~`, or `!~*` operators. For example:

```nginx
if ($request_uri ~ "^/foo/(.*)$") {
    # $1 is now available as a variable
    return 301 /bar/$1;
}
```

**Key improvement:** Capture groups now correctly inherit the boundary (safety constraints) from the source variable being matched. This is critical for HTTP splitting detection:

- `if ($uri ~* ^/echo/(.*)$)` → `$1` inherits `$uri`'s boundary `/[^\x20\t]*` → **can contain `\r\n`** → warning triggered
- `if ($request_uri ~* ^/echo/(.*)$)` → `$1` inherits `$request_uri`'s boundary `/[^\s]*` → **cannot contain `\r\n`** → safe

This distinction matters because:
- `$uri` contains **decoded** bytes (nginx decodes `%0d%0a` → actual `\r\n`)  
- `$request_uri` contains **raw** percent-encoded form (`%0d%0a` stays as-is)

Changes:
- Add `provide_variables = True` to `IfBlock`
- Add `is_regex` property to check for regex operators  
- Add `variables` property that extracts capture groups from the if condition regex with proper boundary inheritance

Fixes #50