### PR TITLE
plugin: detect low keepalive_requests (fixed for crossplane)

### DIFF
--- a/docs/en/plugins/low_keepalive_requests.md
+++ b/docs/en/plugins/low_keepalive_requests.md
@@ -1,0 +1,35 @@
+# Low `keepalive_requests` value
+
+The `keepalive_requests` directive sets the maximum number of requests that can be served through one keep-alive connection. After the maximum number of requests are made, the connection is closed.
+
+## Why this matters
+
+Prior to nginx 1.19.10, the default value was 100. This was raised to 1000 because low values can cause problems:
+
+- **HTTP/2 multiplexing**: Modern browsers open fewer connections but send many requests over each one. A low `keepalive_requests` value forces frequent connection resets.
+- **Client disconnections**: Some clients (especially when using HTTP/2 with proxies like Burp or mitmproxy) may experience failed requests when connections are closed prematurely.
+- **Performance overhead**: Establishing new connections has overhead (TCP handshake, TLS negotiation). Keeping connections alive longer improves performance.
+
+## Bad example
+
+```nginx
+keepalive_requests 100;
+```
+
+This forces connection closure after only 100 requests, which can cause issues with HTTP/2 clients.
+
+## Good example
+
+```nginx
+keepalive_requests 1000;
+```
+
+Or simply omit the directive to use nginx's default (1000 since nginx 1.19.10).
+
+## References
+
+- [nginx documentation: keepalive_requests](https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests)
+- [nginx ticket #2155: Increase default keepalive_requests](https://trac.nginx.org/nginx/ticket/2155)
+
+--8<-- "en/snippets/nginx-extras-cta.md"
+

--- a/gixy/plugins/low_keepalive_requests.py
+++ b/gixy/plugins/low_keepalive_requests.py
@@ -1,0 +1,32 @@
+"""Module for low_keepalive_requests plugin."""
+
+import gixy
+from gixy.plugins.plugin import Plugin
+
+
+class low_keepalive_requests(Plugin):
+    """
+    Insecure example:
+        keepalive_requests 100;
+    """
+
+    summary = "The keepalive_requests directive should be at least 1000."
+    severity = gixy.severity.LOW
+    description = "The keepalive_requests directive should be at least 1000. Any value lower than this may result in client disconnections."
+    help_url = "https://gixy.getpagespeed.com/en/plugins/low_keepalive_requests/"
+    directives = ["keepalive_requests"]
+
+    def audit(self, directive):
+        if not directive.args:
+            return
+        try:
+            value = int(directive.args[0])
+        except (ValueError, TypeError, IndexError):
+            return
+        if value < 1000:
+            self.add_issue(
+                severity=self.severity,
+                directive=[directive],
+                reason="The keepalive_requests directive should be at least 1000.",
+            )
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
     - plugins/unanchored_regex.md
     - plugins/regex_redos.md
     - plugins/worker_rlimit_nofile_vs_connections.md
+    - plugins/low_keepalive_requests.md
   - 'NGINX Extras RPMs': 'https://nginx-extras.getpagespeed.com/'
   - 'Blog': 'https://www.getpagespeed.com/posts'
 markdown_extensions:

--- a/tests/plugins/simply/low_keepalive_requests/low_keepalive_requests.conf
+++ b/tests/plugins/simply/low_keepalive_requests/low_keepalive_requests.conf
@@ -1,0 +1,2 @@
+keepalive_requests 100;
+

--- a/tests/plugins/simply/low_keepalive_requests/low_keepalive_requests_fp.conf
+++ b/tests/plugins/simply/low_keepalive_requests/low_keepalive_requests_fp.conf
@@ -1,0 +1,2 @@
+keepalive_requests 1000;
+


### PR DESCRIPTION
Based on the work from #37 by @MegaManSec, rebased and adapted for the crossplane-based parser.

This PR adds a new plugin to detect when `keepalive_requests` is set below 1000.

`keepalive_requests` was previously defaulting to 100, but this was raised because that value is too low:
- https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests
- https://trac.nginx.org/nginx/ticket/2155

Changes:
- New plugin: `low_keepalive_requests`
- Documentation updates