### PR TITLE
fix(parser): break circular include cycles with active-include guard (#113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Circular `include` directives no longer crash the parser**: nginx configs that contained a cycle (e.g. a file in `/etc/nginx/conf.d/` whose body says `include /etc/nginx/conf.d/*.conf;` — the glob matches the including file itself, or A→B→A across files) sent `gixy/parser/nginx_parser.py` into unbounded recursion. On environments with enough stack budget that surfaced as `RecursionError: maximum recursion depth exceeded` ([#113](https://github.com/dvershinin/gixy/issues/113)); on others the cycle silently inflated the parsed tree with hundreds of duplicated directives. `NginxParser` now tracks the canonical path of every file currently being parsed and skips any include that re-enters one already on the stack, emitting a single `Skipping circular include: …` WARNING per cycle. Applies to both filesystem includes and `nginx -T` dump-mode includes.
+
 ## [0.2.47] - 2026-05-23
 
 ### Added

--- a/gixy/parser/nginx_parser.py
+++ b/gixy/parser/nginx_parser.py
@@ -22,6 +22,9 @@ class NginxParser:
         self.parser = raw_parser.RawParser()
         self._init_directives()
         self._path_stack = None
+        # Canonical paths currently being parsed; consulted by include
+        # resolvers to break cycles. See issue #113.
+        self._active_includes = set()
 
     def parse_file(self, path, root=None, display_path=None):
         """Parse an nginx configuration file from disk.
@@ -47,7 +50,12 @@ class NginxParser:
             raise InvalidConfiguration(error_msg)
 
         current_path = display_path if display_path else path
-        return self._build_tree_from_parsed(parsed, root, current_path)
+        canonical = os.path.realpath(path)
+        self._active_includes.add(canonical)
+        try:
+            return self._build_tree_from_parsed(parsed, root, current_path)
+        finally:
+            self._active_includes.discard(canonical)
 
     def parse_string(self, content, root=None, path_info=None):
         """Parse nginx configuration provided as a string/bytes.
@@ -128,6 +136,7 @@ class NginxParser:
             block.Root: The root containing parsed directives.
         """
         # Handle nginx -T dump format if detected (multi-file with file delimiters)
+        dump_root = None
         if (
             len(parsed_block)
             and isinstance(parsed_block[0], dict)
@@ -138,10 +147,17 @@ class NginxParser:
             self.is_dump = True
             self.cwd = os.path.dirname(root_filename)
             parsed_block = self.configs[root_filename]
+            # Track the virtual dump root for cycle detection. See issue #113.
+            dump_root = root_filename
+            self._active_includes.add(dump_root)
 
         # Parse into the provided root/parent context and keep attribution
         self._path_stack = current_path
-        self.parse_block(parsed_block, root)
+        try:
+            self.parse_block(parsed_block, root)
+        finally:
+            if dump_root is not None:
+                self._active_includes.discard(dump_root)
         self._path_stack = current_path
         return root
 
@@ -261,6 +277,15 @@ class NginxParser:
             if not os.path.exists(file_path):
                 continue
             exists = True
+            # Skip includes that re-enter a file already on the parse stack
+            # (direct or transitive cycle). See issue #113.
+            canonical = os.path.realpath(file_path)
+            if canonical in self._active_includes:
+                LOG.warning(
+                    "Skipping circular include: %s (already being parsed)",
+                    file_path,
+                )
+                continue
             # parse the include into current context
             self.parse_file(file_path, parent)
 
@@ -278,6 +303,15 @@ class NginxParser:
             if not fnmatch.fnmatch(file_path, path):
                 continue
             found = True
+            # Skip dump entries already on the parse stack. Dump paths are
+            # virtual strings — use them directly as cycle keys (no realpath).
+            # See issue #113.
+            if file_path in self._active_includes:
+                LOG.warning(
+                    "Skipping circular include: %s (already being parsed)",
+                    file_path,
+                )
+                continue
 
             # Flatten includes by parsing into the current parent context.
             # We only switch the path stack for correct file attribution but keep
@@ -288,10 +322,13 @@ class NginxParser:
             # sites/default.conf including conf.d/listen → /etc/nginx/conf.d/listen.
             old_stack = self._path_stack
             self._path_stack = file_path
+            self._active_includes.add(file_path)
 
-            self.parse_block(parsed, parent)
-
-            self._path_stack = old_stack
+            try:
+                self.parse_block(parsed, parent)
+            finally:
+                self._active_includes.discard(file_path)
+                self._path_stack = old_stack
 
         if not found:
             # Align behavior with nginx: unmatched glob patterns are not warnings

--- a/tests/parser/test_nginx_parser.py
+++ b/tests/parser/test_nginx_parser.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from gixy.directives.block import *
@@ -230,3 +232,93 @@ def assert_config(config, expected):
     child = tree.children[0]
     for ex in expected:
         assert isinstance(child, ex)
+
+
+# --- Regression tests for issue #113: circular include must not recurse ---
+# Without the guard in NginxParser, these configs silently produced the same
+# directive 100+ times (and on Linux/Python 3.11 with a deeper-per-cycle
+# config, crashed with RecursionError). The guard turns each cycle into one
+# WARNING + a finite tree.
+
+
+def _assert_circular_warning(caplog):
+    """Fail if no WARNING about a circular include was logged."""
+    msgs = [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno >= logging.WARNING and "circular include" in r.getMessage().lower()
+    ]
+    assert msgs, "expected a WARNING about a circular include, got: " + repr(
+        [r.getMessage() for r in caplog.records]
+    )
+
+
+def test_self_include_does_not_recurse(tmp_path, caplog):
+    """A file that literally includes itself must not recurse."""
+    nginx_conf = tmp_path / "nginx.conf"
+    nginx_conf.write_text("user http;\ninclude nginx.conf;\n")
+
+    parser = NginxParser(cwd=str(tmp_path), allow_includes=True)
+    with caplog.at_level(logging.WARNING, logger="gixy.parser.nginx_parser"):
+        tree = parser.parse_file(str(nginx_conf))
+
+    names = [c.name for c in tree.children]
+    assert (
+        names.count("user") == 1
+    ), f"expected one 'user' directive, got {names.count('user')} (tree: {names})"
+    _assert_circular_warning(caplog)
+
+
+def test_glob_self_match_does_not_recurse(tmp_path, caplog):
+    """Realistic case: a file in conf.d/ pulling its own sibling glob.
+
+    Mirrors the shape that admins actually write and which most likely matches
+    the configuration in issue #113.
+    """
+    conf_d = tmp_path / "conf.d"
+    conf_d.mkdir()
+    (tmp_path / "nginx.conf").write_text("user http;\ninclude conf.d/*.conf;\n")
+    (conf_d / "site.conf").write_text(f"server_tokens off;\ninclude {conf_d}/*.conf;\n")
+
+    parser = NginxParser(cwd=str(tmp_path), allow_includes=True)
+    with caplog.at_level(logging.WARNING, logger="gixy.parser.nginx_parser"):
+        tree = parser.parse_file(str(tmp_path / "nginx.conf"))
+
+    names = [c.name for c in tree.children]
+    assert (
+        names.count("server_tokens") == 1
+    ), f"expected one 'server_tokens', got {names.count('server_tokens')} (tree: {names})"
+    assert names.count("user") == 1
+    _assert_circular_warning(caplog)
+
+
+def test_mutual_include_does_not_recurse(tmp_path, caplog):
+    """A → B → A cycle must terminate with each non-include directive once."""
+    (tmp_path / "a.conf").write_text("user http;\ninclude b.conf;\n")
+    (tmp_path / "b.conf").write_text("worker_processes auto;\ninclude a.conf;\n")
+
+    parser = NginxParser(cwd=str(tmp_path), allow_includes=True)
+    with caplog.at_level(logging.WARNING, logger="gixy.parser.nginx_parser"):
+        tree = parser.parse_file(str(tmp_path / "a.conf"))
+
+    names = [c.name for c in tree.children]
+    assert names.count("user") == 1, f"got {names}"
+    assert names.count("worker_processes") == 1, f"got {names}"
+    _assert_circular_warning(caplog)
+
+
+def test_transitive_include_cycle_does_not_recurse(tmp_path, caplog):
+    """A → B → C → A cycle must terminate; catches "only-immediate-include" guards."""
+    (tmp_path / "a.conf").write_text("user http;\ninclude b.conf;\n")
+    (tmp_path / "b.conf").write_text("worker_processes auto;\ninclude c.conf;\n")
+    (tmp_path / "c.conf").write_text("pid /run/nginx.pid;\ninclude a.conf;\n")
+
+    parser = NginxParser(cwd=str(tmp_path), allow_includes=True)
+    with caplog.at_level(logging.WARNING, logger="gixy.parser.nginx_parser"):
+        tree = parser.parse_file(str(tmp_path / "a.conf"))
+
+    names = [c.name for c in tree.children]
+    assert names.count("user") == 1, f"got {names}"
+    assert names.count("worker_processes") == 1, f"got {names}"
+    assert names.count("pid") == 1, f"got {names}"
+    _assert_circular_warning(caplog)


### PR DESCRIPTION
## Summary
- Adds a circular-include guard to `NginxParser`: every file currently being parsed is tracked by canonical path, and any include that re-enters one already on the stack is skipped with a single `Skipping circular include: ...` WARNING.
- Covers both filesystem-mode includes (via `os.path.realpath`) and `nginx -T` dump-mode includes (via the virtual dump path).
- Adds four regression tests in `tests/parser/test_nginx_parser.py` for: self-include, glob-self-match (realistic conf.d pattern), mutual A↔B, and transitive A→B→C→A.

## Why
Fixes #113. Configs containing a cycle — most commonly a file in `conf.d/` whose body says `include /etc/nginx/conf.d/*.conf;` (the glob re-matches the including file) — sent `gixy/parser/nginx_parser.py` into unbounded recursion. On Python 3.11 with enough stack budget that surfaced as `RecursionError: maximum recursion depth exceeded`. On macOS / Python 3.9 the same defect silently inflated the parsed tree with ~200 duplicated copies of every directive in the cycle.

Reproduced both shapes locally before writing the fix; the regression tests assert against the deterministic duplicate-count observable (`names.count('user') == 1`) so they're green across every Python/OS without timing or recursion-limit fiddling. Without the fix the primary test fails with `190 == 1` (190 silent duplicates).

Verified on `~/.virtualenvs/gixy/bin/python -m pytest` — full 800-test suite green.

Real nginx 1.29.6 actually segfaults (SIGSEGV / exit 139) on the same realistic glob-self-match config, so there is no upstream behaviour to mimic here — graceful warn-and-skip is the appropriate gixy behaviour since gixy's job is to analyse configs that may be malformed.

## Test plan
- [x] Red phase: new tests fail on the unmodified parser (`AssertionError: 190 == 1`).
- [x] Green phase: new tests pass with the guard applied.
- [x] Full suite green: `pytest -x` → 800 passed.
- [x] Manual smoke: `gixy /tmp/gixy-glob/nginx.conf` (realistic repro) emits one WARNING line, no traceback, no duplicated output.