### PR TITLE
release: v0.2.49 — add CVE-2026-42530, -42055, -48142

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.49] - 2026-06-18
+
+### Added
+- **`nginx_cves`**: New entry **CVE-2026-42530** — use-after-free in `ngx_http_v3_module`. Affects nginx mainline `1.31.0`..`1.31.1` only when HTTP/3 / QUIC is enabled (`listen … quic` or `http3 on`); stable 1.30.x was never exposed. Mitigation: upgrade to **1.31.2**. Advisory: <https://nvd.nist.gov/vuln/detail/CVE-2026-42530>, F5: <https://my.f5.com/manage/s/article/K000161616>.
+- **`nginx_cves`**: New entry **CVE-2026-42055** — buffer overflow in `ngx_http_proxy_v2_module` / `ngx_http_grpc_module`. Affects nginx OSS `1.13.10`..`1.31.1` when `grpc_pass` is configured or upstream HTTP/2 proxying is enabled (`proxy_http_version 2.0`). Mitigation: upgrade to **1.30.3** (stable) or **1.31.2** (mainline). Advisory: <https://nvd.nist.gov/vuln/detail/CVE-2026-42055>, F5: <https://my.f5.com/manage/s/article/K000161584>.
+- **`nginx_cves`**: New entry **CVE-2026-48142** — buffer overread in `ngx_http_charset_module`. Affects nginx OSS `0.3.50`..`1.31.1` when a non-`off` `charset` directive is configured. Mitigation: upgrade to **1.30.3** (stable) or **1.31.2** (mainline). Advisory: <https://nvd.nist.gov/vuln/detail/CVE-2026-48142>, F5: <https://my.f5.com/manage/s/article/K000161585>.
+
 ## [0.2.48] - 2026-06-04
 
 ### Fixed

--- a/gixy/__init__.py
+++ b/gixy/__init__.py
@@ -2,4 +2,4 @@
 
 from gixy.core import severity
 
-version = "0.2.48"
+version = "0.2.49"

--- a/gixy/plugins/_nginx_cves_db.py
+++ b/gixy/plugins/_nginx_cves_db.py
@@ -587,6 +587,26 @@ def check_proxy_ssl_upstream(root):
             yield directive, directive
 
 
+def check_grpc_or_http2_upstream(root):
+    """Yield directives that activate HTTP/2-based upstream proxying.
+
+    Matches every ``grpc_pass`` directive (gRPC always travels over
+    HTTP/2) and ``proxy_http_version 2.0`` settings. Used for
+    CVE-2026-42055.
+
+    Args:
+        root: Root Block of the parsed config.
+
+    Yields:
+        Tuples of ``(directive, directive)``.
+    """
+    for directive in root.find_recursive("grpc_pass"):
+        yield directive, directive
+    for directive in root.find_recursive("proxy_http_version"):
+        if directive.args and directive.args[0] == "2.0":
+            yield directive, directive
+
+
 def check_proxy_with_http2(root):
     """Yield ``proxy_pass`` directives if HTTP/2 is also enabled.
 
@@ -630,6 +650,39 @@ def _advisory(cve_id):
 
 
 CVES = (
+    {
+        "id": "CVE-2026-42530",
+        "nickname": "",
+        "summary": "Use-after-free in ngx_http_v3_module.",
+        "severity": gixy.severity.HIGH,
+        "advisory": _advisory("CVE-2026-42530"),
+        "vulnerable_oss": (((1, 31, 0), (1, 31, 1)),),
+        "fixed_oss": ("1.31.2",),
+        "fixed_plus": (),
+        "config_check": check_http3_enabled,
+    },
+    {
+        "id": "CVE-2026-42055",
+        "nickname": "",
+        "summary": "Buffer overflow in ngx_http_proxy_v2_module and ngx_http_grpc_module.",
+        "severity": gixy.severity.MEDIUM,
+        "advisory": _advisory("CVE-2026-42055"),
+        "vulnerable_oss": (((1, 13, 10), (1, 31, 1)),),
+        "fixed_oss": ("1.30.3", "1.31.2"),
+        "fixed_plus": (),
+        "config_check": check_grpc_or_http2_upstream,
+    },
+    {
+        "id": "CVE-2026-48142",
+        "nickname": "",
+        "summary": "Buffer overread in ngx_http_charset_module.",
+        "severity": gixy.severity.LOW,
+        "advisory": _advisory("CVE-2026-48142"),
+        "vulnerable_oss": (((0, 3, 50), (1, 31, 1)),),
+        "fixed_oss": ("1.30.3", "1.31.2"),
+        "fixed_plus": (),
+        "config_check": check_charset,
+    },
     {
         "id": "CVE-2026-9256",
         "nickname": "",

--- a/tests/plugins/test_nginx_cves.py
+++ b/tests/plugins/test_nginx_cves.py
@@ -488,3 +488,133 @@ def test_anchor_picks_first_server_for_version_only():
     """Pure version-only CVEs must produce a visible issue location."""
     issues = _run_plugin("0.7.50", _PLAIN)
     assert issues, "ancient version should fire at least one version-only CVE"
+
+
+# --------------------------------------------------------------------------
+# CVEs landed via the 2026-06-17 nginx 1.30.3 / 1.31.2 releases.
+# --------------------------------------------------------------------------
+
+_HTTP3_ON = """events {}
+http {
+    http3 on;
+    server { listen 443 quic reuseport; }
+}
+"""
+
+_GRPC = """events {}
+http {
+    server {
+        listen 80;
+        location /grpc { grpc_pass grpc://upstream:50051; }
+    }
+}
+"""
+
+_PROXY_HTTP2_UPSTREAM = """events {}
+http {
+    server {
+        listen 80;
+        location / {
+            proxy_http_version 2.0;
+            proxy_pass http://upstream;
+        }
+    }
+}
+"""
+
+_CHARSET_ON = """events {}
+http {
+    server { listen 80; charset utf-8; }
+}
+"""
+
+_CHARSET_OFF = """events {}
+http {
+    server { listen 80; charset off; }
+}
+"""
+
+
+def test_cve_2026_42530_fires_with_http3_on_mainline():
+    assert "CVE-2026-42530" in _cves_fired("1.31.1", _HTTP3_ON)
+
+
+def test_cve_2026_42530_silent_without_http3():
+    assert "CVE-2026-42530" not in _cves_fired("1.31.1", _PLAIN)
+
+
+def test_cve_2026_42530_silent_on_mainline_fix():
+    assert "CVE-2026-42530" not in _cves_fired("1.31.2", _HTTP3_ON)
+
+
+def test_cve_2026_42530_silent_on_stable_branches():
+    """Stable 1.30.x was never exposed to CVE-2026-42530."""
+    for version in ("1.30.0", "1.30.3"):
+        assert "CVE-2026-42530" not in _cves_fired(version, _HTTP3_ON), version
+
+
+def test_cve_2026_42055_fires_with_grpc_pass():
+    assert "CVE-2026-42055" in _cves_fired("1.30.0", _GRPC)
+
+
+def test_cve_2026_42055_fires_with_proxy_http_version_2_0():
+    assert "CVE-2026-42055" in _cves_fired("1.30.0", _PROXY_HTTP2_UPSTREAM)
+
+
+def test_cve_2026_42055_silent_without_grpc_or_http2_upstream():
+    assert "CVE-2026-42055" not in _cves_fired("1.31.1", _PLAIN)
+
+
+def test_cve_2026_42055_silent_on_stable_fix():
+    assert "CVE-2026-42055" not in _cves_fired("1.30.3", _GRPC)
+
+
+def test_cve_2026_42055_silent_on_mainline_fix():
+    assert "CVE-2026-42055" not in _cves_fired("1.31.2", _GRPC)
+
+
+def test_cve_2026_42055_silent_before_vulnerable_range():
+    """Pre-1.13.10 (no grpc module yet) must not be flagged."""
+    assert "CVE-2026-42055" not in _cves_fired("1.13.9", _PLAIN)
+
+
+def test_cve_2026_48142_fires_with_charset_on():
+    assert "CVE-2026-48142" in _cves_fired("1.31.0", _CHARSET_ON)
+
+
+def test_cve_2026_48142_silent_with_charset_off():
+    assert "CVE-2026-48142" not in _cves_fired("1.31.0", _CHARSET_OFF)
+
+
+def test_cve_2026_48142_silent_without_charset_directive():
+    assert "CVE-2026-48142" not in _cves_fired("1.31.0", _PLAIN)
+
+
+def test_cve_2026_48142_silent_on_stable_fix():
+    assert "CVE-2026-48142" not in _cves_fired("1.30.3", _CHARSET_ON)
+
+
+def test_cve_2026_48142_silent_on_mainline_fix():
+    assert "CVE-2026-48142" not in _cves_fired("1.31.2", _CHARSET_ON)
+
+
+def test_2026_06_release_cves_silent_on_full_patched_versions():
+    """Spot-check: a config exercising every trigger at fixed versions
+    must not surface any of the three 2026-06 CVEs."""
+    multi = """events {}
+http {
+    http3 on;
+    server {
+        listen 443 quic reuseport;
+        charset utf-8;
+        location /grpc { grpc_pass grpc://upstream:50051; }
+        location /h2 {
+            proxy_http_version 2.0;
+            proxy_pass http://upstream;
+        }
+    }
+}
+"""
+    new_cves = {"CVE-2026-42055", "CVE-2026-48142", "CVE-2026-42530"}
+    assert new_cves.isdisjoint(_cves_fired("1.30.3", multi))
+    assert new_cves.isdisjoint(_cves_fired("1.31.2", multi))


### PR DESCRIPTION
## Summary

nginx 1.30.3 stable and 1.31.2 mainline (2026-06-17) shipped fixes for three new CVEs. Adds entries to `gixy/plugins/_nginx_cves_db.py`:

- **CVE-2026-42530** (HIGH) — use-after-free in `ngx_http_v3_module`; mainline 1.31.0–1.31.1 only. Gated by `check_http3_enabled`.
- **CVE-2026-42055** (MEDIUM) — buffer overflow in `ngx_http_proxy_v2_module` / `ngx_http_grpc_module`; 1.13.10–1.31.1. New helper `check_grpc_or_http2_upstream` matches `grpc_pass` and `proxy_http_version 2.0`.
- **CVE-2026-48142** (LOW) — buffer overread in `ngx_http_charset_module`; 0.3.50–1.31.1. Reuses `check_charset`.

False-positive guarantee asserted by explicit per-CVE "must-not-fire" tests: nginx 1.30.3 and 1.31.2 with every trigger present in one config surface none of these IDs.

## Test plan

- [x] `pytest tests/plugins/test_nginx_cves.py -v` — 54 tests pass (16 new)
- [x] `pytest tests/` — full suite 816 tests pass
- [x] `ruff check` — clean
- [x] Pre-commit hooks (including Python 3.6 sweep) — pass
- [x] Hand-run `gixy --nginx-version {1.31.1,1.31.2,1.30.3,1.30.0}` against grpc+charset and http3 configs — fires on vulnerable, silent on fixed

https://claude.ai/code/session_01CEy7KLvgRt2bfjW4ZdD1Ud